### PR TITLE
Update setup.py to allow hieraarchical install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+# see setup.py
+# pyttsx3 only requires `espeak` driver/library which is system-dependent
+
+### Ubuntu
+#$ sudo apt install espeak
+
+### Mac OS X (os.platform == 'Darwin')
+# pyobjc>=2.4
+
+### Windows (os.platform == 'Windows')
+# pypiwin32
+

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,11 @@ from setuptools import setup
 
 install_requires = []
 if platform.system() == 'Windows':
-    install_requires = [
+    install_requires += [
         'pypiwin32'
     ]
 elif platform.system() == 'Darwin':
-    install_requires = [
+    install_requires += [
         'pyobjc>=2.4'
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ SOFTWARE.'''
 import platform
 from setuptools import setup
 
+# Ubuntu: sudo apt install espeak
 install_requires = []
 if platform.system() == 'Windows':
     install_requires += [


### PR DESCRIPTION
Append `install_requires` list instead of overwriting so that universal" packages can be installed by specifying them within the install_requires list before customizing requirements based on the platform.
 This should facilitate installation on Ubuntu and other linux flavors besides Darwin.