### PR TITLE
fix package requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,19 +23,6 @@ How to install :
 
 
 
-Fixes for possible errors :
-*****************************
-
-* **No module named win32com.client**
-* **No module named win32**
-* **No module named win32api**
-
-::
-
-	pip install pypiwin32
-
-
-
 Usage :
 ************
 ::

--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,14 @@ SOFTWARE.'''
 import platform
 from setuptools import setup
 
-install_requires = []
-if platform.system() == 'Windows':
-    install_requires = [
-        'pypiwin32'
-    ]
-elif platform.system() == 'Darwin':
-    install_requires = [
-        'pyobjc>=2.4'
-    ]
+extras_require = {
+    ':"darwin" in sys_platform': [
+        'pyobjc>=2.4',
+    ],
+    ':"win32" in sys_platform': [
+        'pypiwin32',
+    ],
+}
 
 with open('README.rst' , 'r') as f:
     long_description = f.read() 
@@ -51,5 +50,5 @@ setup(
     #download_url = 'https://github.com/nateshmbhat/pyttsx3/archive/v2.6.tar.gz',
     keywords=['pyttsx' , 'ivona','pyttsx for python3' , 'TTS for python3' , 'pyttsx3' ,'text to speech for python','tts','text to speech','speech','speech synthesis','offline text to speech','offline tts','gtts'],
     classifiers = [] ,
-    install_requires=install_requires
+    extras_require=extras_require
 )


### PR DESCRIPTION
Use `extras_require` to specify platform specific requirements so the generated wheel is valid on all supported platforms (and not just the platform it was generated on).

Before (with the wheel available on PyPI):
```shell
> unzip -p dist/pyttsx3-2.7-py3-none-any.whl '*/METADATA' | grep Require
```
After:
```shell
> unzip -p dist/pyttsx3-2.7-py3-none-any.whl '*/METADATA' | grep Require
Requires-Dist: pyobjc (>=2.4); "darwin" in sys_platform
Requires-Dist: pypiwin32; "win32" in sys_platform
```