### PR TITLE
Fix wheel when built on macos / windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,6 @@ extras_require = {
 }
 
 # Ubuntu: sudo apt install espeak ffmpeg
-install_requires = []
-if platform.system() == 'Windows':
-    install_requires += [
-        'comtypes'
-    ]
-elif platform.system() == 'Darwin':
-    install_requires += [
-        'pyobjc>=2.4'
-    ]
-
 
 with open('README.rst', 'r') as f:
     long_description = f.read()
@@ -37,7 +27,6 @@ setup(
     author='Natesh M Bhat',
     url='https://github.com/nateshmbhat/pyttsx3',
     author_email='nateshmbhatofficial@gmail.com',
-    install_requires=install_requires ,
     keywords=['pyttsx' , 'ivona','pyttsx for python3' , 'TTS for python3' , 'pyttsx3' ,'text to speech for python','tts','text to speech','speech','speech synthesis','offline text to speech','offline tts','gtts'],
     classifiers = [
           'Intended Audience :: End Users/Desktop',


### PR DESCRIPTION
- the platform specific dependencies are already handled by `extras_require`
- when the wheel is built on macos / windows the `install_requires` will contain extra values (it appears the one on pypi for the latest version was built on macos)

Resolves #88
Resolves #87 
Resolves #86
Resolves #83
Resolves #82