### PR TITLE
Fix pypi link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ Feel free to wrap another text-to-speech engine for use with ``pyttsx3``.
 
 ### Project Links :
 
-* PyPI (https://pypi.python.org)
+* PyPI (https://pypi.org/project/pyttsx3/)
 * GitHub (https://github.com/nateshmbhat/pyttsx3)
 * Full Documentation (https://pyttsx3.readthedocs.org)


### PR DESCRIPTION
The pypi link was to pypi, not to the pyttsx project page on pypi.