### PR TITLE
use environment markers for platform specific dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,11 @@ import platform
 from setuptools import setup
 
 
-extras_require = {
-    ':"darwin" in sys_platform': [
-        'pyobjc>=2.4',
-    ],
-    ':"win32" in sys_platform': [
-        'comtypes'
-    ]
-}
-
 # Ubuntu: sudo apt install espeak ffmpeg
-install_requires = []
-if platform.system() == 'Windows':
-    install_requires += [
-        'comtypes'
-    ]
-elif platform.system() == 'Darwin':
-    install_requires += [
-        'pyobjc>=2.4'
-    ]
+install_requires = [
+    'comtypes; platform_system == "Windows"',
+    'pyobjc>=2.4; platform_system == "Darwin"'
+]
 
 
 with open('README.rst', 'r') as f:
@@ -53,5 +39,4 @@ setup(
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7'
     ],
-    extras_require=extras_require
 )


### PR DESCRIPTION
The latest wheel published on PyPI is not installable on Windows or Linux (presumably more releases are affected). This is because the current `setup.py` is querying the platform via code execution. While this will work with source dists, it breaks with wheels - the setup script is executed once when building the wheel, the metadata is written, the setup script is not touched again (in fact, it's not even included in the wheel). This means that e.g. the `pyttsx3-2.84-py3-none-any.whl` was built on MacOS and contains metadata for MacOS, so it is only installable on MacOS, because it pulls `pyobjc-security` on each install attempt.

The solution for this issue is to use the environment markers, specified in [PEP 508](https://www.python.org/dev/peps/pep-0508/#environment-markers). This makes the wheel put platform restriction into metadata, fixing the dependencies resolution.

Signed-off-by: Oleg Höfling <oleg.hoefling@gmail.com>