### PR TITLE
Add support for eSpeak-ng

### DIFF
--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -15,7 +15,10 @@ def cfunc(name, dll, result, *args):
         aflags.append((arg[2], arg[0]) + arg[3:])
     return CFUNCTYPE(result, *atypes)((name, dll), tuple(aflags))
 
-dll = cdll.LoadLibrary('libespeak.so.1')
+try:
+   dll = cdll.LoadLibrary('libespeak-ng.so')
+except:
+   dll = cdll.LoadLibrary('libespeak.so.1')
 
 # constants and such from speak_lib.h
 

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -16,7 +16,7 @@ def cfunc(name, dll, result, *args):
     return CFUNCTYPE(result, *atypes)((name, dll), tuple(aflags))
 
 try:
-   dll = cdll.LoadLibrary('libespeak-ng.so')
+   dll = cdll.LoadLibrary('libespeak-ng.so.1')
 except:
    dll = cdll.LoadLibrary('libespeak.so.1')
 

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -16,7 +16,10 @@ def cfunc(name, dll, result, *args):
     return CFUNCTYPE(result, *atypes)((name, dll), tuple(aflags))
 
 try:
-   dll = cdll.LoadLibrary('libespeak-ng.so.1')
+    try:
+        dll = cdll.LoadLibrary('/usr/local/lib/libespeak-ng.so.1')
+    except:
+        dll = cdll.LoadLibrary('libespeak-ng.so.1')
 except:
    dll = cdll.LoadLibrary('libespeak.so.1')
 


### PR DESCRIPTION
This will enable support for espeak-ng, while keeping epseak functional.