### PR TITLE
Add pitch support to eSpeak-ng

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -1,5 +1,5 @@
 import pyttsx3
-engine = pyttsx3.init() # object creation
+engine = pyttsx3.init(engine='espeak') # object creation
 
 """ RATE"""
 rate = engine.getProperty('rate')   # getting details of current speaking rate
@@ -16,6 +16,11 @@ engine.setProperty('volume',1.0)    # setting up volume level  between 0 and 1
 voices = engine.getProperty('voices')       #getting details of current voice
 #engine.setProperty('voice', voices[0].id)  #changing index, changes voices. o for male
 engine.setProperty('voice', voices[1].id)   #changing index, changes voices. 1 for female
+
+"""PITCH"""
+pitch = engine.getProperty('pitch')   #Get current pitch value
+print(pitch)                          #Print current pitch value
+engine.setProperty('pitch', 75)       #Set the pitch (default 50) to 75 out of 100
 
 engine.say("Hello World!")
 engine.say('My current speaking rate is ' + str(rate))

--- a/example/main.py
+++ b/example/main.py
@@ -1,5 +1,5 @@
 import pyttsx3
-engine = pyttsx3.init(engine='espeak') # object creation
+engine = pyttsx3.init() # object creation
 
 """ RATE"""
 rate = engine.getProperty('rate')   # getting details of current speaking rate

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -14,14 +14,46 @@ def cfunc(name, dll, result, *args):
         aflags.append((arg[2], arg[0]) + arg[3:])
     return CFUNCTYPE(result, *atypes)((name, dll), tuple(aflags))
 
+dll = None
+
+def load_linux_ep():
+   global dll
+   try: dll = cdll.LoadLibrary('libespeak.so.1')
+   except Exception as e: return False
+   else: return True
+
+def load_linux_epng():
+   global dll
+   try: dll = cdll.LoadLibrary('libespeak-ng.so.1')
+   except Exception as e: return False
+   else: return True
+
+def load_linux_epng2():
+   global dll
+   try: dll = cdll.LoadLibrary('/usr/local/lib/libespeak-ng.so.1')
+   except Exception as e: return False
+   else: return True
+
+def load_windows_epng1():
+   global dll
+   try: dll = cdll.LoadLibrary('libespeak-ng.dll')
+   except Exception as e: return False
+   else: return True
+
+def load_windows_epng2():
+   global dll
+   try: dll = cdll.LoadLibrary('C:\\Program Files\\eSpeak NG\\libespeak-ng.dll')
+   except Exception as e: return False
+   else: return True
+
+def load_windows_epng3():
+   global dll
+   try: dll = cdll.LoadLibrary('C:\\Program Files (x86)\\eSpeak NG\\libespeak-ng.dll')
+   except Exception as e: return False
+   else: return True
+
 try:
-    try:
-        try:
-            dll = cdll.LoadLibrary('/usr/local/lib/libespeak-ng.so.1')
-        except:
-            dll = cdll.LoadLibrary('libespeak-ng.so.1')
-    except:
-       dll = cdll.LoadLibrary('libespeak.so.1')
+   load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
 except Exception as exp:
     print("Exception: " + str(exp) + "\n")
     print("This means you probably do not have eSpeak or eSpeak-ng installed!")

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -79,6 +79,8 @@ class EspeakDriver(object):
             return _espeak.GetParameter(_espeak.RATE)
         elif name == 'volume':
             return _espeak.GetParameter(_espeak.VOLUME) / 100.0
+        elif name == 'pitch':
+            return _espeak.GetParameter(_espeak.PITCH)
         else:
             raise KeyError('unknown property %s' % name)
 
@@ -100,6 +102,13 @@ class EspeakDriver(object):
             try:
                 _espeak.SetParameter(
                     _espeak.VOLUME, int(round(value * 100, 2)), 0)
+            except TypeError as e:
+                raise ValueError(str(e))
+        elif name == 'pitch':
+            try:
+                _espeak.SetParameter(
+                    _espeak.PITCH, int(value), 0
+                )
             except TypeError as e:
                 raise ValueError(str(e))
         else:

--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -74,6 +74,8 @@ class NSSpeechDriver(NSObject):
             return self._tts.rate()
         elif name == 'volume':
             return self._tts.volume()
+        elif name == "pitch":
+            print("Pitch adjustment not supported when using NSSS")
         else:
             raise KeyError('unknown property %s' % name)
 
@@ -90,6 +92,8 @@ class NSSpeechDriver(NSObject):
             self._tts.setRate_(value)
         elif name == 'volume':
             self._tts.setVolume_(value)
+        elif name == 'pitch':
+            print("Pitch adjustment not supported when using NSSS")
         else:
             raise KeyError('unknown property %s' % name)
 

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -92,6 +92,8 @@ class SAPI5Driver(object):
             return self._rateWpm
         elif name == 'volume':
             return self._tts.Volume / 100.0
+        elif name == 'pitch':
+            print("Pitch adjustment not supported when using SAPI5")
         else:
             raise KeyError('unknown property %s' % name)
 
@@ -114,6 +116,8 @@ class SAPI5Driver(object):
                 self._tts.Volume = int(round(value * 100, 2))
             except TypeError as e:
                 raise ValueError(str(e))
+        elif name == 'pitch':
+            print("Pitch adjustment not supported when using SAPI5")
         else:
             raise KeyError('unknown property %s' % name)
 


### PR DESCRIPTION
This PR adds pitch adjustment to espeak-ng, adds handling of pitch to other TTS engines to prevent errors, and cleans up a messy try/except block I added in a previous PR. It has worked through my test cases, (Tested on Windows, WSL, and Arch Linux).

This primarily addresses issue #164 

I also updated the example/main.py file to show the new feature.