### PR TITLE
Fix typo in Documentation

### DIFF
--- a/docs/engine.rst
+++ b/docs/engine.rst
@@ -61,7 +61,7 @@ The Engine interface
 
       .. describe:: finished-utterance
 
-         Fired when the engine finishes speaking an utterance. The associated callback must have the folowing signature.
+         Fired when the engine finishes speaking an utterance. The associated callback must have the following signature.
 
          .. function:: onFinishUtterance(name : string, completed : bool) -> None
 


### PR DESCRIPTION
under describe:: finished-utterance
"...have the folowing signature." was changed to "...have the following signature."