### PR TITLE
Use .get to avoid KeyError on voice attributes

### DIFF
--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -1,7 +1,7 @@
-
-from Foundation import *
 from AppKit import NSSpeechSynthesizer
+from Foundation import *
 from PyObjCTools import AppHelper
+
 from ..voice import Voice
 
 
@@ -55,13 +55,9 @@ class NSSpeechDriver(NSObject):
 
     @objc.python_method
     def _toVoice(self, attr):
-        try:
-            lang = attr['VoiceLocaleIdentifier']
-        except KeyError:
-            lang = attr['VoiceLanguage']
-        return Voice(attr['VoiceIdentifier'], attr['VoiceName'],
-                     [lang], attr['VoiceGender'],
-                     attr['VoiceAge'])
+        return Voice(attr.get('VoiceIdentifier'), attr.get('VoiceName'),
+                     [attr.get('VoiceLocaleIdentifier', attr.get('VoiceLanguage'))], attr.get('VoiceGender'),
+                     attr.get('VoiceAge'))
 
     @objc.python_method
     def getProperty(self, name):


### PR DESCRIPTION
* Use `.get` to avoid `KeyError` on voice attributes

Upon updating to macOS Ventura 13.0, I identified that it lacks the key `VoiceAge` among its attributes. Instead of using `[]` to get the dict values, I switched it to `.get` which is also a more safe and pythonic way of getting dict values. I do not have access to raise a PR.

* Add `.get` for `VoiceLocaleIdentifier` as well

Remove exception handler that might in turn raise another exception