### PR TITLE
NSSS MacOS Ventura workaround

### DIFF
--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -101,6 +101,7 @@ class NSSpeechDriver(NSObject):
     def save_to_file(self, text, filename):
         url = Foundation.NSURL.fileURLWithPath_(filename)
         self._tts.startSpeakingString_toURL_(text, url)
+        from time import sleep; sleep(0.5) # FIXME: this is a workaround to make save_to_file working in MacOS Ventura.
 
     def speechSynthesizer_didFinishSpeaking_(self, tts, success):
         if not self._completed:

--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -101,7 +101,7 @@ class NSSpeechDriver(NSObject):
     def save_to_file(self, text, filename):
         url = Foundation.NSURL.fileURLWithPath_(filename)
         self._tts.startSpeakingString_toURL_(text, url)
-        from time import sleep; sleep(0.5) # FIXME: this is a workaround to make save_to_file working in MacOS Ventura.
+        from time import sleep; sleep(0.1) # FIXME: this is a workaround to make save_to_file working in MacOS Ventura.
 
     def speechSynthesizer_didFinishSpeaking_(self, tts, success):
         if not self._completed:


### PR DESCRIPTION
If I trying to save TTS result to file in MacOS Ventura (on Apple Silicon CPU), pyttsx3 generating empty file with 4kb size.

I found a simple way to fix it - adding a small timeout after saving operation. Looks like engine.runAndWait() closing loop before file content is saving. Maybe a reason in Apple Silicon CPU speedup, or it's pyobj bug. However, this workaround is working, and someone can found better solution in future.