### PR TITLE
Resolves #142 for empty save_to_file() on darwin platform (NSSS driver)

### DIFF
--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -99,6 +99,8 @@ class NSSpeechDriver(NSObject):
 
     @objc.python_method
     def save_to_file(self, text, filename):
+        self._proxy.setBusy(True)
+        self._completed = True
         url = Foundation.NSURL.fileURLWithPath_(filename)
         self._tts.startSpeakingString_toURL_(text, url)
 


### PR DESCRIPTION
I traced the empty file / hanging behavior to `_busy` state management in the driver proxy. The underlying `NSSpeechSynthesizer` object behaves similarly for `say()` and `save_to_file()`, but `save_to_file()` was not updating the busy and completion states before starting synthesis the way that `say()` does. The state mismanagement caused the second call to `save_to_file()` to start an event loop that would never be terminated.

The intentions of the state management in the driver proxy are not perfectly clear to me, so this may not be a completely robust fix, but it does resolve the hanging behavior. Please note that you still must save `.aiff` or `.wav` files with the NSSS driver, not `.mp3`.