### PR TITLE
Use any available voice if a match is not found with sapi5

### DIFF
--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -80,6 +80,7 @@ class SAPI5Driver(object):
         tokens = self._tts.GetVoices()
         id_ = id_.replace("Speech_OneCore", "Speech") # https://stackoverflow.com/questions/65660897/pyttsx3-unknown-voice-id
         for token in tokens:
+            print(token)
             if token.Id == id_:
                 return token
         raise ValueError('unknown voice id %s', id_)

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -80,10 +80,10 @@ class SAPI5Driver(object):
         tokens = self._tts.GetVoices()
         id_ = id_.replace("Speech_OneCore", "Speech") # https://stackoverflow.com/questions/65660897/pyttsx3-unknown-voice-id
         for token in tokens:
-            print(token.Id, id_)
             if token.Id == id_:
                 return token
-        raise ValueError('unknown voice id %s', id_)
+        return tokens[0] # return any voice if not found
+        #raise ValueError('unknown voice id %s', id_)
 
     def getProperty(self, name):
         if name == 'voices':

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -82,8 +82,11 @@ class SAPI5Driver(object):
         for token in tokens:
             if token.Id == id_ or token.Id == id2_:
                 return token
-        return tokens[0] # return any voice if not found
-        #raise ValueError('unknown voice id %s', id_)
+
+        if len(tokens) > 0:
+            return tokens[0] # return any voice if not found
+        else:
+            raise ValueError('unknown voice id %s', id_)
 
     def getProperty(self, name):
         if name == 'voices':

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -86,7 +86,7 @@ class SAPI5Driver(object):
         if len(tokens) > 0:
             return tokens[0] # return any voice if not found
         else:
-            raise ValueError('unknown voice id %s', id_)
+            raise ValueError('unknown voice id %s and no alternative voices found', id_)
 
     def getProperty(self, name):
         if name == 'voices':

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -78,6 +78,7 @@ class SAPI5Driver(object):
 
     def _tokenFromId(self, id_):
         tokens = self._tts.GetVoices()
+        id_ = id_.replace("Speech_OneCore", "Speech") # https://stackoverflow.com/questions/65660897/pyttsx3-unknown-voice-id
         for token in tokens:
             if token.Id == id_:
                 return token

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -78,9 +78,9 @@ class SAPI5Driver(object):
 
     def _tokenFromId(self, id_):
         tokens = self._tts.GetVoices()
-        id_ = id_.replace("Speech_OneCore", "Speech") # https://stackoverflow.com/questions/65660897/pyttsx3-unknown-voice-id
+        id2_ = id_.replace("Speech_OneCore", "Speech") # https://stackoverflow.com/questions/65660897/pyttsx3-unknown-voice-id
         for token in tokens:
-            if token.Id == id_:
+            if token.Id == id_ or token.Id == id2_:
                 return token
         return tokens[0] # return any voice if not found
         #raise ValueError('unknown voice id %s', id_)

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -80,7 +80,7 @@ class SAPI5Driver(object):
         tokens = self._tts.GetVoices()
         id_ = id_.replace("Speech_OneCore", "Speech") # https://stackoverflow.com/questions/65660897/pyttsx3-unknown-voice-id
         for token in tokens:
-            print(token)
+            print(token.Id, id_)
             if token.Id == id_:
                 return token
         raise ValueError('unknown voice id %s', id_)


### PR DESCRIPTION
The registry keys for some sapi5 voices have changed, along with their names, resulting in a failure to obtain an exact string match.  When this occurs, this revision defaults to the first voice in the list of drivers, or returns a ValueError if no voices are found.