### PR TITLE
fixes for word events, correct finding of espeak and playing of espeak

### DIFF
--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -1,12 +1,13 @@
-
-
 from __future__ import print_function
-from ctypes import cdll, c_int, c_char_p, c_wchar_p, POINTER, c_short, c_uint, c_long, c_void_p
-from ctypes import CFUNCTYPE, Structure, Union, c_wchar, c_ubyte, c_ulong, byref
+
 import time
+from ctypes import (CFUNCTYPE, POINTER, Structure, Union, c_char_p, c_int,
+                    c_long, c_short, c_ubyte, c_uint, c_ulong, c_void_p,
+                    c_wchar, cdll)
+
 
 def cfunc(name, dll, result, *args):
-    '''build and apply a ctypes prototype complete with parameter flags'''
+    """build and apply a ctypes prototype complete with parameter flags"""
     atypes = []
     aflags = []
     for arg in args:
@@ -14,52 +15,40 @@ def cfunc(name, dll, result, *args):
         aflags.append((arg[2], arg[0]) + arg[3:])
     return CFUNCTYPE(result, *atypes)((name, dll), tuple(aflags))
 
+
 dll = None
 
-def load_linux_ep():
-   global dll
-   try: dll = cdll.LoadLibrary('libespeak.so.1')
-   except Exception as e: return False
-   else: return True
-
-def load_linux_epng():
-   global dll
-   try: dll = cdll.LoadLibrary('libespeak-ng.so.1')
-   except Exception as e: return False
-   else: return True
-
-def load_linux_epng2():
-   global dll
-   try: dll = cdll.LoadLibrary('/usr/local/lib/libespeak-ng.so.1')
-   except Exception as e: return False
-   else: return True
-
-def load_windows_epng1():
-   global dll
-   try: dll = cdll.LoadLibrary('libespeak-ng.dll')
-   except Exception as e: return False
-   else: return True
-
-def load_windows_epng2():
-   global dll
-   try: dll = cdll.LoadLibrary('C:\\Program Files\\eSpeak NG\\libespeak-ng.dll')
-   except Exception as e: return False
-   else: return True
-
-def load_windows_epng3():
-   global dll
-   try: dll = cdll.LoadLibrary('C:\\Program Files (x86)\\eSpeak NG\\libespeak-ng.dll')
-   except Exception as e: return False
-   else: return True
+def load_library():
+    global dll
+    paths = [
+        # macOS paths
+        '/usr/local/lib/libespeak-ng.1.dylib',
+        '/usr/local/lib/libespeak.dylib',
+        
+        # Linux paths
+        'libespeak-ng.so.1',
+        '/usr/local/lib/libespeak-ng.so.1',
+        'libespeak.so.1',
+        
+        # Windows paths
+        r'C:\Program Files\eSpeak NG\libespeak-ng.dll',
+        r'C:\Program Files (x86)\eSpeak NG\libespeak-ng.dll'
+    ]
+    
+    for path in paths:
+        try:
+            dll = cdll.LoadLibrary(path)
+            return True
+        except Exception:
+            continue  # Try the next path
+    return False
 
 try:
-   load_linux_ep() or load_linux_epng() or load_linux_epng2() or load_windows_epng1() or load_windows_epng2() or load_windows_epng3()
+    if not load_library():
+        raise RuntimeError("This means you probably do not have eSpeak or eSpeak-ng installed!")
 except Exception as exp:
-    print("Exception: " + str(exp) + "\n")
-    print("This means you probably do not have eSpeak or eSpeak-ng installed!")
-    import sys
-    sys.exit()
-
+    raise
+    
 # constants and such from speak_lib.h
 
 EVENT_LIST_TERMINATED = 0
@@ -70,12 +59,14 @@ EVENT_PLAY = 4
 EVENT_END = 5
 EVENT_MSG_TERMINATED = 6
 
+
 class numberORname(Union):
     _fields_ = [
         ('number', c_int),
         ('name', c_char_p)
-        ]
-    
+    ]
+
+
 class EVENT(Structure):
     _fields_ = [
         ('type', c_int),
@@ -86,8 +77,9 @@ class EVENT(Structure):
         ('sample', c_int),
         ('user_data', c_void_p),
         ('id', numberORname)
-        ]
-    
+    ]
+
+
 AUDIO_OUTPUT_PLAYBACK = 0
 AUDIO_OUTPUT_RETRIEVAL = 1
 AUDIO_OUTPUT_SYNCHRONOUS = 2
@@ -103,25 +95,28 @@ Initialize = cfunc('espeak_Initialize', dll, c_int,
                    ('bufflength', c_int, 1, 100),
                    ('path', c_char_p, 1, None),
                    ('option', c_int, 1, 0))
-Initialize.__doc__ = '''Must be called before any synthesis functions are called.
+Initialize.__doc__ = """Must be called before any synthesis functions are called.
   output: the audio data can either be played by eSpeak or passed back by the SynthCallback function. 
   buflength:  The length in mS of sound buffers passed to the SynthCallback function.
   path: The directory which contains the espeak-data directory, or NULL for the default location.
   options: bit 0: 1=allow espeakEVENT_PHONEME events.
 
-  Returns: sample rate in Hz, or -1 (EE_INTERNAL_ERROR).'''
+  Returns: sample rate in Hz, or -1 (EE_INTERNAL_ERROR)."""
 
 t_espeak_callback = CFUNCTYPE(c_int, POINTER(c_short), c_int, POINTER(EVENT))
 
 cSetSynthCallback = cfunc('espeak_SetSynthCallback', dll, None,
-                        ('SynthCallback', t_espeak_callback, 1))
+                          ('SynthCallback', t_espeak_callback, 1))
 SynthCallback = None
+
+
 def SetSynthCallback(cb):
     global SynthCallback
     SynthCallback = t_espeak_callback(cb)
     cSetSynthCallback(SynthCallback)
 
-SetSynthCallback.__doc__ = '''Must be called before any synthesis functions are called.
+
+SetSynthCallback.__doc__ = """Must be called before any synthesis functions are called.
    This specifies a function in the calling program which is called when a buffer of
    speech sound data has been produced. 
 
@@ -141,19 +136,22 @@ int SynthCallback(short *wav, int numsamples, espeak_EVENT *events);
       also the occurance if <mark> and <audio> elements within the text.
 
 
-   Callback returns: 0=continue synthesis,  1=abort synthesis.'''
+   Callback returns: 0=continue synthesis,  1=abort synthesis."""
 
 t_UriCallback = CFUNCTYPE(c_int, c_int, c_char_p, c_char_p)
 
 cSetUriCallback = cfunc('espeak_SetUriCallback', dll, None,
-                       ('UriCallback', t_UriCallback, 1))
+                        ('UriCallback', t_UriCallback, 1))
 UriCallback = None
+
+
 def SetUriCallback(cb):
     global UriCallback
     UriCallback = t_UriCallback(UriCallback)
     cSetUriCallback(UriCallback)
 
-SetUriCallback.__doc__ = '''This function must be called before synthesis functions are used, in order to deal with
+
+SetUriCallback.__doc__ = """This function must be called before synthesis functions are used, in order to deal with
    <audio> tags.  It specifies a callback function which is called when an <audio> element is
    encountered and allows the calling program to indicate whether the sound file which
    is specified in the <audio> element is available and is to be played.
@@ -170,37 +168,38 @@ int UriCallback(int type, const char *uri, const char *base);
 
    Return: 1=don't play the sound, but speak the text alternative.
            0=place a PLAY event in the event list at the point where the <audio> element
-             occurs.  The calling program can then play the sound at that point.'''
-
+             occurs.  The calling program can then play the sound at that point."""
 
 # a few manifest constants
-CHARS_AUTO =  0
-CHARS_UTF8 =  1
-CHARS_8BIT =  2
+CHARS_AUTO = 0
+CHARS_UTF8 = 1
+CHARS_8BIT = 2
 CHARS_WCHAR = 3
 
-SSML          = 0x10
-PHONEMES      = 0x100
-ENDPAUSE      = 0x1000
+SSML = 0x10
+PHONEMES = 0x100
+ENDPAUSE = 0x1000
 KEEP_NAMEDATA = 0x2000
 
 POS_CHARACTER = 1
-POS_WORD      = 2
-POS_SENTENCE  = 3
+POS_WORD = 2
+POS_SENTENCE = 3
+
 
 def Synth(text, position=0, position_type=POS_CHARACTER, end_position=0, flags=0, user_data=None):
-    return cSynth(text, len(text)*10, position, position_type, end_position, flags, None, user_data)
+    return cSynth(text, len(text) * 10, position, position_type, end_position, flags, None, user_data)
+
 
 cSynth = cfunc('espeak_Synth', dll, c_int,
-              ('text', c_char_p, 1),
-              ('size', c_long, 1),
-              ('position', c_uint, 1, 0),
-              ('position_type', c_int, 1, POS_CHARACTER),
-              ('end_position', c_uint, 1, 0),
-              ('flags', c_uint, 1, CHARS_AUTO),
-              ('unique_identifier', POINTER(c_uint), 1, None),
-              ('user_data', c_void_p, 1, None))
-Synth.__doc__ = '''Synthesize speech for the specified text.  The speech sound data is passed to the calling
+               ('text', c_char_p, 1),
+               ('size', c_long, 1),
+               ('position', c_uint, 1, 0),
+               ('position_type', c_int, 1, POS_CHARACTER),
+               ('end_position', c_uint, 1, 0),
+               ('flags', c_uint, 1, CHARS_AUTO),
+               ('unique_identifier', POINTER(c_uint), 1, None),
+               ('user_data', c_void_p, 1, None))
+Synth.__doc__ = """Synthesize speech for the specified text.  The speech sound data is passed to the calling
    program in buffers by means of the callback function specified by espeak_SetSynthCallback(). The command is asynchronous: it is internally buffered and returns as soon as possible. If espeak_Initialize was previously called with AUDIO_OUTPUT_PLAYBACK as argument, the sound data are played by eSpeak.
 
    text: The text to be spoken, terminated by a zero character. It may be either 8-bit characters,
@@ -242,20 +241,22 @@ Synth.__doc__ = '''Synthesize speech for the specified text.  The speech sound d
    Return: EE_OK: operation achieved 
            EE_BUFFER_FULL: the command can not be buffered; 
              you may try after a while to call the function again.
-	   EE_INTERNAL_ERROR.'''
+	   EE_INTERNAL_ERROR."""
+
 
 def Synth_Mark(text, index_mark, end_position=0, flags=CHARS_AUTO):
-    cSynth_Mark(text, len(text)+1, index_mark, end_position, flags)
+    cSynth_Mark(text, len(text) + 1, index_mark, end_position, flags)
+
 
 cSynth_Mark = cfunc('espeak_Synth_Mark', dll, c_int,
-                   ('text', c_char_p, 1),
-                   ('size', c_ulong, 1),
-                   ('index_mark', c_char_p, 1),
-                   ('end_position', c_uint, 1, 0),
-                   ('flags', c_uint, 1, CHARS_AUTO),
-                   ('unique_identifier', POINTER(c_uint), 1, None),
-                   ('user_data', c_void_p, 1, None))
-Synth_Mark.__doc__ = '''Synthesize speech for the specified text.  Similar to espeak_Synth() but the start position is
+                    ('text', c_char_p, 1),
+                    ('size', c_ulong, 1),
+                    ('index_mark', c_char_p, 1),
+                    ('end_position', c_uint, 1, 0),
+                    ('flags', c_uint, 1, CHARS_AUTO),
+                    ('unique_identifier', POINTER(c_uint), 1, None),
+                    ('user_data', c_void_p, 1, None))
+Synth_Mark.__doc__ = """Synthesize speech for the specified text.  Similar to espeak_Synth() but the start position is
    specified by the name of a <mark> element in the text.
 
    index_mark:  The "name" attribute of a <mark> element within the text which specified the
@@ -263,50 +264,50 @@ Synth_Mark.__doc__ = '''Synthesize speech for the specified text.  Similar to es
 
    For the other parameters, see espeak_Synth()
 
-   Return: EE_OK: operation achieved 
-           EE_BUFFER_FULL: the command can not be buffered; 
+   Return:  EE_OK: operation achieved 
+            EE_BUFFER_FULL: the command can not be buffered; 
              you may try after a while to call the function again.
-	   EE_INTERNAL_ERROR.'''
+	        EE_INTERNAL_ERROR."""
 
 Key = cfunc('espeak_Key', dll, c_int,
             ('key_name', c_char_p, 1))
-Key.__doc__ = '''Speak the name of a keyboard key.
+Key.__doc__ = """Speak the name of a keyboard key.
    Currently this just speaks the "key_name" as given 
 
    Return: EE_OK: operation achieved 
            EE_BUFFER_FULL: the command can not be buffered; 
              you may try after a while to call the function again.
-	   EE_INTERNAL_ERROR.'''
+	   EE_INTERNAL_ERROR."""
 
 Char = cfunc('espeak_Char', dll, c_int,
              ('character', c_wchar, 1))
-Char.__doc__ = '''Speak the name of the given character 
+Char.__doc__ = """Speak the name of the given character 
 
    Return: EE_OK: operation achieved 
            EE_BUFFER_FULL: the command can not be buffered; 
              you may try after a while to call the function again.
-	   EE_INTERNAL_ERROR.'''
+	   EE_INTERNAL_ERROR."""
 
 # Speech Parameters
-SILENCE=0  #internal use
-RATE=1
-VOLUME=2
-PITCH=3
-RANGE=4
-PUNCTUATION=5
-CAPITALS=6
-EMPHASIS=7   # internal use
-LINELENGTH=8 # internal use
+SILENCE = 0  # internal use
+RATE = 1
+VOLUME = 2
+PITCH = 3
+RANGE = 4
+PUNCTUATION = 5
+CAPITALS = 6
+EMPHASIS = 7  # internal use
+LINELENGTH = 8  # internal use
 
-PUNCT_NONE=0
-PUNCT_ALL=1
-PUNCT_SOME=2
+PUNCT_NONE = 0
+PUNCT_ALL = 1
+PUNCT_SOME = 2
 
 SetParameter = cfunc('espeak_SetParameter', dll, c_int,
                      ('parameter', c_int, 1),
                      ('value', c_int, 1),
                      ('relative', c_int, 1, 0))
-SetParameter.__doc__ = '''Sets the value of the specified parameter.
+SetParameter.__doc__ = """Sets the value of the specified parameter.
    relative=0   Sets the absolute value of the parameter.
    relative=1   Sets a relative value of the parameter.
 
@@ -321,7 +322,7 @@ SetParameter.__doc__ = '''Sets the value of the specified parameter.
 
       espeak.PUNCTUATION:  which punctuation characters to announce:
          value in espeak_PUNCT_TYPE (none, all, some), 
-	 see espeak_GetParameter() to specify which characters are announced.
+         see espeak_GetParameter() to specify which characters are announced.
 
       espeak.CAPITALS: announce capital letters by:
          0=none,
@@ -333,43 +334,45 @@ SetParameter.__doc__ = '''Sets the value of the specified parameter.
    Return: EE_OK: operation achieved 
            EE_BUFFER_FULL: the command can not be buffered; 
              you may try after a while to call the function again.
-	   EE_INTERNAL_ERROR.'''
+           EE_INTERNAL_ERROR."""
 
 GetParameter = cfunc('espeak_GetParameter', dll, c_int,
                      ('parameter', c_int, 1))
-GetParameter.__doc__ = '''current=0  Returns the default value of the specified parameter.
-   current=1  Returns the current value of the specified parameter, as set by SetParameter()'''
+GetParameter.__doc__ = """current=0  Returns the default value of the specified parameter.
+   current=1  Returns the current value of the specified parameter, as set by SetParameter()"""
 
 SetPunctuationList = cfunc('espeak_SetPunctuationList', dll, c_int,
                            ('punctlist', c_wchar, 1))
-SetPunctuationList.__doc__ = '''Specified a list of punctuation characters whose names are to be spoken when the value of the Punctuation parameter is set to "some".
+SetPunctuationList.__doc__ = """Specified a list of punctuation characters whose names are 
+to be spoken when the value of the Punctuation parameter is set to "some".
 
    punctlist:  A list of character codes, terminated by a zero character.
 
-   Return: EE_OK: operation achieved 
-           EE_BUFFER_FULL: the command can not be buffered; 
+   Return:  EE_OK: operation achieved 
+            EE_BUFFER_FULL: the command can not be buffered; 
              you may try after a while to call the function again.
-	   EE_INTERNAL_ERROR.'''
-                           
+            EE_INTERNAL_ERROR."""
+
 SetPhonemeTrace = cfunc('espeak_SetPhonemeTrace', dll, None,
                         ('value', c_int, 1),
                         ('stream', c_void_p, 1))
-SetPhonemeTrace.__doc__ = '''Controls the output of phoneme symbols for the text
+SetPhonemeTrace.__doc__ = """Controls the output of phoneme symbols for the text
    value=0  No phoneme output (default)
    value=1  Output the translated phoneme symbols for the text
    value=2  as (1), but also output a trace of how the translation was done (matching rules and list entries)
 
-   stream   output stream for the phoneme symbols (and trace).  If stream=NULL then it uses stdout.'''
+   stream   output stream for the phoneme symbols (and trace).  If stream=NULL then it uses stdout."""
 
 CompileDictionary = cfunc('espeak_CompileDictionary', dll, None,
                           ('path', c_char_p, 1),
                           ('log', c_void_p, 1))
-CompileDictionary.__doc__ = '''Compile pronunciation dictionary for a language which corresponds to the currently
+CompileDictionary.__doc__ = """Compile pronunciation dictionary for a language which corresponds to the currently
    selected voice.  The required voice should be selected before calling this function.
 
    path:  The directory which contains the language's '_rules' and '_list' files.
           'path' should end with a path separator character ('/').
-   log:   Stream for error reports and statistics information. If log=NULL then stderr will be used.'''
+   log:   Stream for error reports and statistics information. If log=NULL then stderr will be used."""
+
 
 class VOICE(Structure):
     _fields_ = [
@@ -382,30 +385,32 @@ class VOICE(Structure):
         ('xx1', c_ubyte),
         ('score', c_int),
         ('spare', c_void_p),
-        ]
+    ]
+
     def __repr__(self):
-        '''Print the fields'''
+        """Print the fields"""
         res = []
         for field in self._fields_:
             res.append('%s=%s' % (field[0], repr(getattr(self, field[0]))))
         return self.__class__.__name__ + '(' + ','.join(res) + ')'
-        
+
 
 cListVoices = cfunc('espeak_ListVoices', dll, POINTER(POINTER(VOICE)),
                     ('voice_spec', POINTER(VOICE), 1))
-cListVoices.__doc__ = '''Reads the voice files from espeak-data/voices and creates an array of espeak_VOICE pointers.
+cListVoices.__doc__ = """Reads the voice files from espeak-data/voices and creates an array of espeak_VOICE pointers.
    The list is terminated by a NULL pointer
 
    If voice_spec is NULL then all voices are listed.
    If voice spec is given, then only the voices which are compatible with the voice_spec
-   are listed, and they are listed in preference order.'''
+   are listed, and they are listed in preference order."""
+
 
 def ListVoices(voice_spec=None):
-    '''Reads the voice files from espeak-data/voices and returns a list of VOICE objects.
+    """Reads the voice files from espeak-data/voices and returns a list of VOICE objects.
 
    If voice_spec is None then all voices are listed.
    If voice spec is given, then only the voices which are compatible with the voice_spec
-   are listed, and they are listed in preference order.'''
+   are listed, and they are listed in preference order."""
     ppv = cListVoices(voice_spec)
     res = []
     i = 0
@@ -414,19 +419,20 @@ def ListVoices(voice_spec=None):
         i += 1
     return res
 
+
 SetVoiceByName = cfunc('espeak_SetVoiceByName', dll, c_int,
                        ('name', c_char_p, 1))
-SetVoiceByName.__doc__ = '''Searches for a voice with a matching "name" field.  Language is not considered.
+SetVoiceByName.__doc__ = """Searches for a voice with a matching "name" field.  Language is not considered.
    "name" is a UTF8 string.
 
-   Return: EE_OK: operation achieved 
-           EE_BUFFER_FULL: the command can not be buffered; 
+   Return:   EE_OK: operation achieved 
+             EE_BUFFER_FULL: the command can not be buffered; 
              you may try after a while to call the function again.
-	   EE_INTERNAL_ERROR.'''
+             EE_INTERNAL_ERROR."""
 
 SetVoiceByProperties = cfunc('espeak_SetVoiceByProperties', dll, c_int,
                              ('voice_spec', POINTER(VOICE), 1))
-SetVoiceByProperties.__doc__ = '''An espeak_VOICE structure is used to pass criteria to select a voice.  Any of the following
+SetVoiceByProperties.__doc__ = """An espeak_VOICE structure is used to pass criteria to select a voice.  Any of the following
    fields may be set:
 
    name     NULL, or a voice name
@@ -439,38 +445,37 @@ SetVoiceByProperties.__doc__ = '''An espeak_VOICE structure is used to pass crit
 
    variant  After a list of candidates is produced, scored and sorted, "variant" is used to index
             that list and choose a voice.
-            variant=0 takes the top voice (i.e. best match). variant=1 takes the next voice, etc'''
+            variant=0 takes the top voice (i.e. best match). variant=1 takes the next voice, etc"""
 
 GetCurrentVoice = cfunc('espeak_GetCurrentVoice', dll, POINTER(VOICE),
                         )
-GetCurrentVoice.__doc__ = '''Returns the espeak_VOICE data for the currently selected voice.
-   This is not affected by temporary voice changes caused by SSML elements such as <voice> and <s>'''
+GetCurrentVoice.__doc__ = """Returns the espeak_VOICE data for the currently selected voice.
+   This is not affected by temporary voice changes caused by SSML elements such as <voice> and <s>"""
 
 Cancel = cfunc('espeak_Cancel', dll, c_int)
-Cancel.__doc__ = '''Stop immediately synthesis and audio output of the current text. When this
+Cancel.__doc__ = """Stop immediately synthesis and audio output of the current text. When this
    function returns, the audio output is fully stopped and the synthesizer is ready to
    synthesize a new message.
 
-   Return: EE_OK: operation achieved 
-	   EE_INTERNAL_ERROR.'''
+   Return:  EE_OK: operation achieved 
+            EE_INTERNAL_ERROR."""
 
 IsPlaying = cfunc('espeak_IsPlaying', dll, c_int)
-IsPlaying.__doc__ = '''Returns 1 if audio is played, 0 otherwise.'''
+IsPlaying.__doc__ = """Returns 1 if audio is played, 0 otherwise."""
 
 Synchronize = cfunc('espeak_Synchronize', dll, c_int)
-Synchronize.__doc__ = '''This function returns when all data have been spoken.
-   Return: EE_OK: operation achieved 
-	   EE_INTERNAL_ERROR.'''
+Synchronize.__doc__ = """This function returns when all data have been spoken.
+   Return:  EE_OK: operation achieved 
+	        EE_INTERNAL_ERROR."""
 
 Terminate = cfunc('espeak_Terminate', dll, c_int)
-Terminate.__doc__ = '''last function to be called.
-   Return: EE_OK: operation achieved 
-	   EE_INTERNAL_ERROR.'''
+Terminate.__doc__ = """last function to be called.
+   Return:  EE_OK: operation achieved 
+	        EE_INTERNAL_ERROR."""
 
-Info = cfunc('espeak_Info', dll, c_char_p,
-             ('ptr', c_void_p, 1, 0))
-Info.__doc__ = '''Returns the version number string.
-   The parameter is for future use, and should be set to NULL'''
+Info = cfunc('espeak_Info', dll, c_char_p, ('ptr', c_void_p, 1, 0))
+Info.__doc__ = """Returns the version number string.
+The parameter is for future use, and should be set to NULL"""
 
 if __name__ == '__main__':
     def synth_cb(wav, numsample, events):
@@ -479,17 +484,17 @@ if __name__ == '__main__':
         while True:
             if events[i].type == EVENT_LIST_TERMINATED:
                 break
-            print (events[i].type, end="")
+            print(events[i].type, end="")
             i += 1
-        print
         return 0
+
 
     samplerate = Initialize(output=AUDIO_OUTPUT_PLAYBACK)
     SetSynthCallback(synth_cb)
     s = 'This is a test, only a test. '
     uid = c_uint(0)
-    #print 'pitch=',GetParameter(PITCH)
-    #SetParameter(PITCH, 50, 0)
+    # print 'pitch=',GetParameter(PITCH)
+    # SetParameter(PITCH, 50, 0)
     print(Synth(s))
     while IsPlaying():
         time.sleep(0.1)

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -1,18 +1,23 @@
-
-import time
-import ctypes
-import io
-import wave
 import os
+import wave
+import platform
+import ctypes
+import time
+import subprocess
 from tempfile import NamedTemporaryFile
+if platform.system() == 'Windows':
+    import winsound
+
 from ..voice import Voice
-from . import _espeak, toUtf8, fromUtf8
+from . import _espeak, fromUtf8, toUtf8
 
 
+# noinspection PyPep8Naming
 def buildDriver(proxy):
     return EspeakDriver(proxy)
 
 
+# noinspection PyPep8Naming
 class EspeakDriver(object):
     _moduleInitialized = False
     _defaultVoice = ''
@@ -21,22 +26,24 @@ class EspeakDriver(object):
         if not EspeakDriver._moduleInitialized:
             # espeak cannot initialize more than once per process and has
             # issues when terminating from python (assert error on close)
-            # so just keep it alive and init once
+            # so just keep it alive and init once        
             rate = _espeak.Initialize(_espeak.AUDIO_OUTPUT_RETRIEVAL, 1000)
             if rate == -1:
                 raise RuntimeError('could not initialize espeak')
             EspeakDriver._defaultVoice = 'default'
             EspeakDriver._moduleInitialized = True
+        self._proxy = proxy
+        self._looping = False
+        self._stopping = False
+        self._speaking = False
+        self._text_to_say = None
+        self._data_buffer = b''
+        self._numerise_buffer = []
+
         _espeak.SetSynthCallback(self._onSynth)
-        # make sure all props reset
         self.setProperty('voice', EspeakDriver._defaultVoice)
         self.setProperty('rate', 200)
         self.setProperty('volume', 1.0)
-        self._proxy = proxy
-        self._looping = True
-        self._stopping = False
-        self._data_buffer = b''
-        self._numerise_buffer = []
 
     def numerise(self, data):
         self._numerise_buffer.append(data)
@@ -45,29 +52,29 @@ class EspeakDriver(object):
     def decode_numeric(self, data):
         return self._numerise_buffer[int(data) - 1]
 
-    def destroy(self):
+    @staticmethod
+    def destroy():
         _espeak.SetSynthCallback(None)
-
-    def say(self, text):
-        self._proxy.setBusy(True)
-        self._proxy.notify('started-utterance')
-        _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE |
-                      _espeak.CHARS_UTF8)
 
     def stop(self):
         if _espeak.IsPlaying():
             self._stopping = True
+            _espeak.Cancel()
 
-    def getProperty(self, name):
+    @staticmethod
+    def getProperty(name: str):
         if name == 'voices':
             voices = []
             for v in _espeak.ListVoices(None):
-                kwargs = {}
-                kwargs['id'] = fromUtf8(v.name)
-                kwargs['name'] = fromUtf8(v.name)
+                kwargs = {'id': fromUtf8(v.name), 'name': fromUtf8(v.name)}
                 if v.languages:
-                    kwargs['languages'] = [v.languages]
-                genders = [None, 'male', 'female']
+                    try:
+                        language_code_bytes = v.languages[1:]
+                        language_code = language_code_bytes.decode('utf-8', errors='ignore')
+                        kwargs['languages'] = [language_code]
+                    except UnicodeDecodeError as e:
+                        kwargs['languages'] = ["Unknown"]
+                    genders = [None, 'male', 'female']
                 kwargs['gender'] = genders[v.gender]
                 kwargs['age'] = v.age or None
                 voices.append(Voice(**kwargs))
@@ -84,7 +91,8 @@ class EspeakDriver(object):
         else:
             raise KeyError('unknown property %s' % name)
 
-    def setProperty(self, name, value):
+    @staticmethod
+    def setProperty(name: str, value):
         if name == 'voice':
             if value is None:
                 return
@@ -114,43 +122,22 @@ class EspeakDriver(object):
         else:
             raise KeyError('unknown property %s' % name)
 
-    def startLoop(self):
-        first = True
-        self._stopping = False
-        self._looping = True
-        while self._looping:
-            if first:
-                # kick the queue
-                self._proxy.setBusy(False)
-                first = False
-            if self._stopping and self._looping:
-                # have to do the cancel on the main thread, not inside the
-                # callback else deadlock
-                _espeak.Cancel()
-                self._stopping = False
-                self._proxy.notify('finished-utterance', completed=False)
-                self._proxy.setBusy(False)
-            time.sleep(0.01)
-
     def save_to_file(self, text, filename):
         code = self.numerise(filename)
-        _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE |
-                    _espeak.CHARS_UTF8, user_data=code)
+        _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE | _espeak.CHARS_UTF8, user_data=code)
 
-    def endLoop(self):
-        self._looping = False
+    def _start_synthesis(self, text):
+        self._proxy.setBusy(True)
+        self._proxy.notify('started-utterance')
+        self._speaking = True
+        self._data_buffer = b''  # Ensure buffer is cleared before starting
+        try:
+            _espeak.Synth(toUtf8(text), flags=_espeak.ENDPAUSE | _espeak.CHARS_UTF8)
+        except Exception as e:
+            self._proxy.setBusy(False)
+            self._proxy.notify('error', exception=e)
+            raise
 
-    def iterate(self):
-        self._proxy.setBusy(False)
-        while 1:
-            if self._stopping:
-                # have to do the cancel on the main thread, not inside the
-                # callback else deadlock
-                _espeak.Cancel()
-                self._stopping = False
-                self._proxy.notify('finished-utterance', completed=False)
-                self._proxy.setBusy(False)
-            yield
 
     def _onSynth(self, wav, numsamples, events):
         i = 0
@@ -159,29 +146,88 @@ class EspeakDriver(object):
             if event.type == _espeak.EVENT_LIST_TERMINATED:
                 break
             if event.type == _espeak.EVENT_WORD:
-                self._proxy.notify('started-word',
-                                   location=event.text_position - 1,
-                                   length=event.length)
-            elif event.type == _espeak.EVENT_MSG_TERMINATED:
-                stream = NamedTemporaryFile()
-
-                with wave.open(stream, 'wb') as f:
-                    f.setnchannels(1)
-                    f.setsampwidth(2)
-                    f.setframerate(22050.0)
-                    f.writeframes(self._data_buffer)
-
-                if event.user_data:
-                    os.system('ffmpeg -y -i {} {} -loglevel quiet'.format(stream.name, self.decode_numeric(event.user_data)))
+                
+                if self._text_to_say:
+                    start_index = event.text_position-1
+                    end_index = start_index + event.length
+                    word = self._text_to_say[start_index:end_index]
                 else:
-                    os.system('aplay {} -q'.format(stream.name))  # -q for quiet
+                    word = "Unknown"
 
-                self._data_buffer = b''
+                self._proxy.notify('started-word', name=word, location=event.text_position, length=event.length)
+
+            elif event.type == _espeak.EVENT_END:
+                stream = NamedTemporaryFile(delete=False, suffix='.wav')
+    
+                try:
+                    with wave.open(stream, 'wb') as f:
+                        f.setnchannels(1)
+                        f.setsampwidth(2)
+                        f.setframerate(22050.0)
+                        f.writeframes(self._data_buffer)
+                    self._data_buffer = b''
+    
+                    if event.user_data:
+                        os.system(f'ffmpeg -y -i {stream.name} {self.decode_numeric(event.user_data)} -loglevel quiet')
+                    else:
+                        if platform.system() == 'Darwin':  # macOS
+                            try:
+                                result = subprocess.run(['afplay', stream.name], check=True, capture_output=True, text=True)
+                            except subprocess.CalledProcessError as e:
+                                raise RuntimeError(f"[EspeakDriver._onSynth] Mac afplay failed with error: {e}")
+                        elif platform.system() == 'Linux':
+                            os.system(f'aplay {stream.name} -q')
+                        elif platform.system() == 'Windows':
+                            winsound.PlaySound(stream.name, winsound.SND_FILENAME)  # Blocking playback
+    
+                except Exception as e:
+                    raise RuntimeError(f"Error during playback: {e}")
+    
+                finally:
+                    try:
+                        stream.close()  # Ensure the file is closed
+                        os.remove(stream.name)
+                    except Exception as e:
+                        raise RuntimeError(f"Error deleting temporary WAV file: {e}")
+    
                 self._proxy.notify('finished-utterance', completed=True)
                 self._proxy.setBusy(False)
+                self.endLoop()  # End the loop here
+                break  # Exit the loop after handling the termination event
+    
             i += 1
-        
+    
         if numsamples > 0:
-            self._data_buffer += ctypes.string_at(wav, numsamples *
-                                                ctypes.sizeof(ctypes.c_short))
+            self._data_buffer += ctypes.string_at(wav, numsamples * ctypes.sizeof(ctypes.c_short))
         return 0
+
+    
+    def endLoop(self):
+        self._looping = False
+    
+    def startLoop(self):
+        first = True
+        self._looping = True
+        while self._looping:
+            if not self._looping:
+                break
+            if first:
+                self._proxy.setBusy(False)
+                first = False
+                if self._text_to_say:
+                    self._start_synthesis(self._text_to_say)
+            self.iterate()
+            time.sleep(0.01)
+    
+    def iterate(self):
+        if not self._looping:
+            return
+        if self._stopping:
+            _espeak.Cancel()
+            self._stopping = False
+            self._proxy.notify('finished-utterance', completed=False)
+            self._proxy.setBusy(False)
+            self.endLoop()
+
+    def say(self, text):
+        self._text_to_say = text


### PR DESCRIPTION
So I found eSpeak totally broken for me on all platforms. Yet to fully test on Linux. This now does word event timings as the normal code and speaks on MacOS and Windows. Apologies for all those docstring changes. Think that might be vscode being overly helpful. 