### PR TITLE
SAPI and NSSS word events

### DIFF
--- a/pyttsx3/driver.py
+++ b/pyttsx3/driver.py
@@ -57,6 +57,7 @@ class DriverProxy(object):
         self._name = None
         self._iterator = None
         self._debug = debug
+        self._current_text = ''
 
     def __del__(self):
         try:
@@ -102,7 +103,8 @@ class DriverProxy(object):
         @param kwargs: Arbitrary keyword arguments
         @type kwargs: dict
         '''
-        kwargs['name'] = self._name
+        if 'name' not in kwargs or kwargs['name'] is None:  # Avoid overwriting
+            kwargs['name'] = self._name
         self._engine._notify(topic, **kwargs)
 
     def setBusy(self, busy):
@@ -132,6 +134,7 @@ class DriverProxy(object):
         @param name: Name to associate with the utterance
         @type name: str
         '''
+        self._current_text = text
         self._push(self._driver.say, (text,), name)
 
     def stop(self):

--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -37,6 +37,7 @@ class NSSpeechDriver(NSObject):
         self._proxy = None
         self._tts = None
         self._completed = False
+        self._current_text = ''
 
     @objc.python_method
     def initWithProxy(self, proxy):
@@ -91,6 +92,7 @@ class NSSpeechDriver(NSObject):
         self._proxy.setBusy(True)
         self._completed = True
         self._proxy.notify('started-utterance')
+        self._current_text = text
         self._tts.startSpeakingString_(text)
 
     def stop(self):
@@ -154,5 +156,10 @@ class NSSpeechDriver(NSObject):
         self._proxy.setBusy(False)
 
     def speechSynthesizer_willSpeakWord_ofString_(self, tts, rng, text):
-        self._proxy.notify('started-word', location=rng.location,
+        if self._current_text:
+            current_word = self._current_text[rng.location:rng.location + rng.length]
+        else:
+            current_word = "Unknown"
+
+        self._proxy.notify('started-word', name=current_word, location=rng.location,
                            length=rng.length)


### PR DESCRIPTION
If you run

```python
import pyttsx3
def onStart(name):
   print('starting', name)
def onWord(name, location, length):
   print('word', name, location, length)
def onEnd(name, completed):
   print('finishing', name, completed)
engine = pyttsx3.init()
engine.connect('started-utterance', onStart)
engine.connect('started-word', onWord)
engine.connect('finished-utterance', onEnd)
engine.say('The quick brown fox jumped over the lazy dog.')
engine.runAndWait()

```

on SAPI it was still broken. Im not sure how - but I think one of the PRs cancelled out our changes. Nay mind this PR is better now as we now get

```bash
starting None
word The 0 3
word quick 4 5
word brown 10 5
word fox 16 3
word jumped 20 6
word over 27 4
word the 32 3
word lazy 36 4
word dog. 41 4
finishing None True
```

This works on SAPI and NSSS (NB: It already worked on espeak)
