### PR TITLE
DRAFT attempt at fixing event loop

### DIFF
--- a/pyttsx3/driver.py
+++ b/pyttsx3/driver.py
@@ -49,6 +49,7 @@ class DriverProxy(object):
         self._engine = engine
         self._queue = []
         self._busy = True
+        self._looping = False
         self._name = None
         self._iterator = None
         self._debug = debug
@@ -193,15 +194,19 @@ class DriverProxy(object):
         """
         Called by the engine to start an event loop.
         """
+        print("driver.startLoop setting looping to true..")
+        self._looping = True
         if useDriverLoop:
             self._driver.startLoop()
         else:
-            self._iterator = self._driver.iterate()
+            self._iterator = self._driver.iterate() or iter([])
 
     def endLoop(self, useDriverLoop):
         """
         Called by the engine to stop an event loop.
         """
+        print("DriverProxy.endLoop called, setting looping to False")
+        self._looping = False
         self._queue = []
         self._driver.stop()
         if useDriverLoop:

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -212,6 +212,8 @@ def Synth(
     flags=0,
     user_data=None,
 ):
+    if isinstance(text, str):
+        text = text.encode("utf-8")
     return cSynth(
         text,
         len(text) * 10,
@@ -528,16 +530,31 @@ The parameter is for future use, and should be set to NULL"""
 if __name__ == "__main__":
 
     def synth_cb(wav, numsample, events):
-        print(numsample, end="")
+        print(f"Callback received: numsample={numsample}")
         i = 0
         while True:
-            if events[i].type == EVENT_LIST_TERMINATED:
+            event_type = events[i].type
+            if event_type == EVENT_LIST_TERMINATED:
+                print("Event: LIST_TERMINATED")
                 break
-            print(events[i].type, end="")
+            elif event_type == EVENT_WORD:
+                print("Event: WORD")
+            elif event_type == EVENT_SENTENCE:
+                print("Event: SENTENCE")
+            elif event_type == EVENT_MARK:
+                print("Event: MARK")
+            elif event_type == EVENT_PLAY:
+                print("Event: PLAY")
+            elif event_type == EVENT_END:
+                print("Event: END")
+            elif event_type == EVENT_MSG_TERMINATED:
+                print("Event: MSG_TERMINATED")
+            else:
+                print(f"Unknown event type: {event_type}")
             i += 1
         return 0
 
-    samplerate = Initialize(output=AUDIO_OUTPUT_PLAYBACK)
+    samplerate = Initialize(output=AUDIO_OUTPUT_RETRIEVAL)
     SetSynthCallback(synth_cb)
     s = "This is a test, only a test. "
     uid = c_uint(0)

--- a/pyttsx3/drivers/espeak.py
+++ b/pyttsx3/drivers/espeak.py
@@ -34,7 +34,8 @@ class EspeakDriver(object):
             EspeakDriver._defaultVoice = "default"
             EspeakDriver._moduleInitialized = True
         self._proxy = proxy
-        self._looping = False
+        print("espeak init setting looping to false..")
+        self._proxy._looping = False
         self._stopping = False
         self._speaking = False
         self._text_to_say = None
@@ -59,6 +60,7 @@ class EspeakDriver(object):
         _espeak.SetSynthCallback(None)
 
     def stop(self):
+        print("EspeakDriver.stop called, setting _stopping to True")
         if _espeak.IsPlaying():
             self._stopping = True
             _espeak.Cancel()
@@ -167,53 +169,17 @@ class EspeakDriver(object):
                     location=event.text_position,
                     length=event.length,
                 )
-
             elif event.type == _espeak.EVENT_MSG_TERMINATED:
-                # Final event indicating synthesis completion
-                if self._save_file:
-                    try:
-                        with wave.open(self._save_file, "wb") as f:
-                            f.setnchannels(1)  # Mono
-                            f.setsampwidth(2)  # 16-bit samples
-                            f.setframerate(22050)  # 22,050 Hz sample rate
-                            f.writeframes(self._data_buffer)
-                        print(f"Audio saved to {self._save_file}")
-                    except Exception as e:
-                        raise RuntimeError(f"Error saving WAV file: {e}")
-                else:
-                    try:
-                        with NamedTemporaryFile(
-                            suffix=".wav", delete=False
-                        ) as temp_wav:
-                            with wave.open(temp_wav, "wb") as f:
-                                f.setnchannels(1)  # Mono
-                                f.setsampwidth(2)  # 16-bit samples
-                                f.setframerate(22050)  # 22,050 Hz sample rate
-                                f.writeframes(self._data_buffer)
-
-                            temp_wav_name = temp_wav.name
-                            temp_wav.flush()
-
-                        # Playback functionality (for say method)
-                        if platform.system() == "Darwin":  # macOS
-                            subprocess.run(["afplay", temp_wav_name], check=True)
-                        elif platform.system() == "Linux":
-                            os.system(f"aplay {temp_wav_name} -q")
-                        elif platform.system() == "Windows":
-                            winsound.PlaySound(temp_wav_name, winsound.SND_FILENAME)
-
-                        # Remove the file after playback
-                        os.remove(temp_wav_name)
-                    except Exception as e:
-                        print(f"Playback error: {e}")
-
-                # Clear the buffer and mark as finished
-                self._data_buffer = b""
-                self._speaking = False
-                self._proxy.notify("finished-utterance", completed=True)
-                self._proxy.setBusy(False)
-                self.endLoop()
+                print("EVENT_MSG_TERMINATED detected, ending loop.")
+                # Ensure the loop stops when synthesis completes
+                self._proxy._looping = False
+                if not self._is_external_loop:
+                    self.endLoop()  # End loop only if not in an external loop
                 break
+            elif event.type == _espeak.EVENT_END:
+                print("EVENT_END detected.")
+                # Optional: handle end of an utterance if applicable
+                pass
 
             i += 1
 
@@ -226,31 +192,50 @@ class EspeakDriver(object):
         return 0
 
     def endLoop(self):
-        self._looping = False
+        print("Ending loop...")
+        print("EspeakDriver.endLoop called, setting looping to False")
+        self._proxy._looping = False
 
-    def startLoop(self):
-        first = True
-        self._looping = True
-        while self._looping:
-            if not self._looping:
+    def startLoop(self, external=False):
+        print(f"EspeakDriver: Entering startLoop (external={external})")
+        self._proxy._looping = True
+        self._is_external_loop = external  # Track if it's an external loop
+        timeout = time.time() + 10
+        while self._proxy._looping:
+            if time.time() > timeout:
+                print("Exiting startLoop due to timeout.")
+                self._proxy._looping = False
                 break
-            if first:
-                self._proxy.setBusy(False)
-                first = False
-                if self._text_to_say:
-                    self._start_synthesis(self._text_to_say)
-            self.iterate()
+            print("EspeakDriver loop iteration")
+            if self._text_to_say:
+                self._start_synthesis(self._text_to_say)
+            try:
+                next(self.iterate())
+            except StopIteration:
+                print("StopIteration in startLoop")
+                break
             time.sleep(0.01)
 
+        print("EspeakDriver: Exiting startLoop")
+
     def iterate(self):
-        if not self._looping:
+        print("running espeak iterate once")
+        if not self._proxy._looping:
+            print("Not looping, returning from iterate...")
             return
         if self._stopping:
             _espeak.Cancel()
+            print("Exiting iterate due to stop.")
             self._stopping = False
             self._proxy.notify("finished-utterance", completed=False)
             self._proxy.setBusy(False)
+            self._proxy._looping = False  # Mark the loop as done
+            return
+
+        # Only call endLoop in an internal loop, leave external control to external loop handler
+        if not self._is_external_loop:
             self.endLoop()
+        yield  # Yield back to `startLoop`
 
     def say(self, text):
         self._text_to_say = text

--- a/test.py
+++ b/test.py
@@ -1,0 +1,76 @@
+import time
+import ctypes
+from unittest import mock
+
+import pyttsx3
+
+# Initialize the pyttsx3 engine
+engine = pyttsx3.init("espeak")
+
+
+# Set up event listeners for debugging
+def on_start(name):
+    print(f"[DEBUG] Started utterance: {name}")
+    print(f"Started utterance: {name}")
+
+
+def on_word(name, location, length):
+    print(f"Word: {name} at {location} with length {length}")
+    # Interrupt the utterance if location is above a threshold to simulate test_interrupting_utterance
+    if location > 10:
+        print("Interrupting utterance by calling endLoop...")
+        engine.endLoop()  # Directly call endLoop instead of stop
+
+
+def on_end(name, completed):
+    print(f"Finished utterance: {name}, completed: {completed}")
+
+
+# Connect the listeners
+engine.connect("started-utterance", on_start)
+engine.connect("started-word", on_word)
+engine.connect("finished-utterance", on_end)
+
+
+# Demo for test_interrupting_utterance
+def demo_interrupting_utterance():
+    print("\nRunning demo_interrupting_utterance...")
+    engine.say("The quick brown fox jumped over the lazy dog.")
+    engine.runAndWait()
+    engine.endLoop()
+
+
+# Demo for test_external_event_loop
+def demo_external_event_loop():
+    print("\nRunning demo_external_event_loop...")
+
+    def external_loop():
+        # Simulate external loop iterations
+        for _ in range(5):
+            engine.iterate()  # Process engine events
+            time.sleep(0.5)  # Adjust timing as needed
+
+    engine.say("The quick brown fox jumped over the lazy dog.")
+    engine.startLoop(False)  # Start loop without blocking
+    external_loop()
+    engine.endLoop()  # End the event loop explicitly
+
+
+# Run demos
+demo_interrupting_utterance()
+from pyinstrument import Profiler
+
+# Initialize the profiler
+profiler = Profiler()
+
+# Start profiling
+profiler.start()
+
+# Run the external event loop demo
+demo_external_event_loop()
+
+# Stop profiling
+profiler.stop()
+
+# Print the profiling report
+profiler.print()


### PR DESCRIPTION
@cclauss  - can you run this through your tests - it is an attempt to fix the external event loop

Its got a lot of debug lines in it .. 

If it basically works i'll remove these. 

the biggest change really is this in _onSynth


```
 elif event.type == _espeak.EVENT_MSG_TERMINATED:
                print("EVENT_MSG_TERMINATED detected, ending loop.")
                # Ensure the loop stops when synthesis completes
                self._proxy._looping = False
                if not self._is_external_loop:
                    self.endLoop()  # End loop only if not in an external loop
                break
```