### PR TITLE
TTS engines by sys.platform

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -27,8 +27,7 @@ jobs:
           sudo apt-get install --yes espeak-ng libespeak1
           espeak-ng --version
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,8 +37,7 @@ jobs:
           pip install pytest pytest-timeout
           pip install --editable .
 
-      - name: Run tests
-        run: pytest
+      - run: pytest -s -vvv --timeout=600
 
   build:
     runs-on: ubuntu-latest

--- a/pyttsx3/driver.py
+++ b/pyttsx3/driver.py
@@ -1,7 +1,6 @@
-import sys
+import importlib
 import traceback
 import weakref
-import importlib
 
 
 class DriverProxy(object):
@@ -25,22 +24,18 @@ class DriverProxy(object):
     @type _iterator: iterator
     """
 
-    def __init__(self, engine, driverName, debug):
+    def __init__(self, engine, driverName: str, debug: bool):
         """
         Constructor.
 
         @param engine: Reference to the engine that owns the driver
         @type engine: L{engine.Engine}
-        @param driverName: Name of the driver module to use under drivers/ or
-            None to select the default for the platform
+        @param driverName: Name of the driver module to use under drivers/
         @type driverName: str
         @param debug: Debugging output enabled or not
         @type debug: bool
         """
-        driverName = driverName or {
-            "darwin": "nsss",
-            "win32": "sapi5",
-        }.get(sys.platform, "espeak")
+        assert driverName
         # import driver module
         self._module = importlib.import_module(f"pyttsx3.drivers.{driverName}")
         # build driver instance

--- a/tests/test_pyttsx3.py
+++ b/tests/test_pyttsx3.py
@@ -1,4 +1,5 @@
-import os
+from __future__ import annotations
+
 import sys
 from unittest import mock
 
@@ -9,11 +10,18 @@ import pyttsx3
 
 
 @pytest.fixture
-def engine():
+def engine(driver_name: str | None = None) -> pyttsx3.engine.Engine:
     """Fixture for initializing pyttsx3 engine."""
-    engine = pyttsx3.init()
+    engine = pyttsx3.init(driver_name)
     yield engine
     engine.stop()  # Ensure the engine stops after tests
+
+
+def test_engine_name(engine):
+    expected = pyttsx3.engine.default_engine_by_sys_platform()
+    assert engine.driver_name == expected
+    assert str(engine) == expected
+    assert repr(engine) == f"pyttsx3.engine.Engine('{expected}', debug=False)"
 
 
 # Test for speaking text


### PR DESCRIPTION
Add `Engine.driver_name` and pytests for it.

Use Python [`sys.platform()`](https://docs.python.org/3/library/sys.html#sys.platform) to return all TTS Engines for the current OS.  The first TTS Engine in the tuple will be the default Engine for that OS.
```python
# https://docs.python.org/3/library/sys.html#sys.platform
# The keys are values of Python sys.platform, the values are tuples of engine names.
# The first engine in the value tuple is the default engine for that platform.
_engines_by_sys_platform = {
    "darwin": ("nsss", "espeak"),  # NSSpeechSynthesizer (deprecated)
    "win32": ("sapi5", "espeak"),
}


def engines_by_sys_platform() -> tuple[str]:
    """
    Return the names of all TTS engines for the current operating system.
    If sys.platform is not in _engines_by_sys_platform, return ("espeak",).
    """
    return _engines_by_sys_platform.get(sys.platform, ("espeak",))


def default_engine_by_sys_platform() -> str:
    """
    Return the name of the default TTS engine for the current operating system.
    The first engine in the value tuple is the default engine for that platform.
    """
    return engines_by_sys_platform()[0]
```