### PR TITLE
Enable eSpeak-NG on macOS

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -31,10 +31,12 @@ jobs:
     timeout-minutes: 10  # Save resources while our pytests are hanging
     steps:
       - if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -q -q
-          sudo apt-get install --yes espeak-ng libespeak1
-          espeak-ng --version
+        run: sudo apt-get update -q -q && sudo apt-get install --yes espeak-ng libespeak1
+      - if: runner.os == 'macOS'
+        run: brew install espeak-ng
+      - if: runner.os != 'Windows'
+        run: espeak-ng --version
+
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -46,7 +48,7 @@ jobs:
           pip install pytest pytest-timeout
           pip install --editable .
 
-      - run: pytest -s -vvv --timeout=600
+      - run: pytest -s -vvv --strict --timeout=600
 
   build:
     runs-on: ubuntu-latest

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -36,6 +36,7 @@ def load_library():
     global dll
     paths = [
         # macOS paths
+        "/opt/homebrew/lib/libespeak-ng.1.dylib",
         "/usr/local/lib/libespeak-ng.1.dylib",
         "/usr/local/lib/libespeak.dylib",
         # Linux paths

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import pyttsx3
+
+quick_brown_fox = "The quick brown fox jumped over the lazy dog."
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="TODO: Install eSpeak-NG on Windows"
+)
+@pytest.mark.parametrize("driver_name", pyttsx3.engine.engines_by_sys_platform())
+def test_engine_name(driver_name):
+    engine = pyttsx3.init(driver_name)
+    assert engine.driver_name == driver_name
+    assert str(engine) == driver_name
+    assert repr(engine) == f"pyttsx3.engine.Engine('{driver_name}', debug=False)"
+    engine.stop()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="TODO: Install eSpeak-NG on Windows"
+)
+@pytest.mark.parametrize("driver_name", pyttsx3.engine.engines_by_sys_platform())
+def test_speaking_text(driver_name):
+    engine = pyttsx3.init(driver_name)
+    engine.say("Sally sells seashells by the seashore.")
+    engine.say(quick_brown_fox)
+    print(list(pyttsx3._activeEngines.values()), flush=True)
+    engine.runAndWait()
+    print(list(pyttsx3._activeEngines.values()), flush=True)
+    engine.stop()

--- a/tests/test_pyttsx3.py
+++ b/tests/test_pyttsx3.py
@@ -39,7 +39,7 @@ def test_speaking_text(engine):
 @pytest.mark.skipif(
     sys.platform not in ("darwin", "ios"), reason="Testing only on macOS and iOS"
 )
-def test_apple__nsss_voices(engine):
+def test_apple_nsss_voices(engine):
     import platform
 
     macos_version, _, macos_hardware = platform.mac_ver()
@@ -70,7 +70,7 @@ def test_apple__nsss_voices(engine):
         engine.setProperty("voice", _voice.id)
         name = _voice.id.split(".")[-1]
         names.append(name)
-        engine.say(f"{name} says {quick_brown_fox}")
+        engine.say(f"{name} says hello")
     name_str = ", ".join(names)
     assert name_str == "Eddy, Flo, Grandma, Grandpa, Reed, Rocko, Sandy, Shelley"
     print(f"({name_str})", end=" ", flush=True)


### PR DESCRIPTION
###  `pytest -s -vvv --full-trace --strict`

% `brew info espeak-ng`
% `brew home espeak-ng`
% `brew install espeak-ng`
% `espeak-ng --version`