### PR TITLE
Fix `python pyttsx3/drivers/_espeak.py`

### DIFF
--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -542,8 +542,8 @@ if __name__ == "__main__":
     SetSynthCallback(synth_cb)
     s = "This is a test, only a test. "
     uid = c_uint(0)
-    # print 'pitch=',GetParameter(PITCH)
+    # print('pitch=',GetParameter(PITCH))
     # SetParameter(PITCH, 50, 0)
-    print(Synth(s))
+    print(Synth(s.encode("utf-8")))
     while IsPlaying():
         time.sleep(0.1)

--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -213,6 +213,8 @@ def Synth(
     flags=0,
     user_data=None,
 ):
+    if isinstance(text, str):
+        text = text.encode("utf-8")
     return cSynth(
         text,
         len(text) * 10,
@@ -544,6 +546,6 @@ if __name__ == "__main__":
     uid = c_uint(0)
     # print('pitch=',GetParameter(PITCH))
     # SetParameter(PITCH, 50, 0)
-    print(Synth(s.encode("utf-8")))
+    print(Synth(s))
     while IsPlaying():
         time.sleep(0.1)


### PR DESCRIPTION
```diff
def Synth(
    text,
    position=0,
    position_type=POS_CHARACTER,
    end_position=0,
    flags=0,
    user_data=None,
):
+   if isinstance(text, str):
+       text = text.encode("utf-8")
    return cSynth(
        text,
```
Before:
% `python pyttsx3/drivers/_espeak.py`
```
ctypes.ArgumentError: argument 1: TypeError: 'str' object cannot be interpreted as ctypes.c_char_p
```
After: eSpeak-NG pronounces the message.