### PR TITLE
Apple NSSpeechSynthesizer (`nsss`) writes .aiff, not .wav files

### DIFF
--- a/example/repeatvoice.py
+++ b/example/repeatvoice.py
@@ -1,7 +1,7 @@
-import pyttsx3  # pyttsx3 is a text-to-speech conversion library in Python
-import speech_recognition as s  # Google Speech API in Python
+# pip3 install SpeechRecognition
 
-# Functional programming Model
+import pyttsx3  # A text-to-speech conversion library in Python
+import speech_recognition  # A speech-to-text conversion library in Python
 
 
 def text_to_speech(text):
@@ -14,11 +14,13 @@ def text_to_speech(text):
 
 
 def speech_to_text():
-    r = s.Recognizer()  # an object r which recognises the voice
-    with s.Microphone():
-        # when using with statement. The with statement itself ensures proper acquisition and release of resources
-        print(r.recognize_google(audio))  # noqa: F821
-        text_to_speech(r.recognize_google(audio))  # noqa: F821
+    recognizer = speech_recognition.Recognizer()
+    with speech_recognition.Microphone() as microphone:
+        audio = recognizer.listen(microphone)
+    text = recognizer.recognize_google(audio)
+    print(text)
+    text_to_speech(text)
 
 
-speech_to_text()
+if __name__ == "__main__":
+    speech_to_text()

--- a/example/repeatvoice.py
+++ b/example/repeatvoice.py
@@ -17,8 +17,8 @@ def speech_to_text():
     r = s.Recognizer()  # an object r which recognises the voice
     with s.Microphone():
         # when using with statement. The with statement itself ensures proper acquisition and release of resources
-        print(r.recognize_google(audio))
-        text_to_speech(r.recognize_google(audio))
+        print(r.recognize_google(audio))  # noqa: F821
+        text_to_speech(r.recognize_google(audio))  # noqa: F821
 
 
 speech_to_text()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,3 @@ include-package-data = false
 [tool.ruff]
 target-version = "py39"
 line-length = 88
-lint.extend-ignore = [ "F403", "F405", "F821" ]

--- a/pyttsx3/drivers/nsss.py
+++ b/pyttsx3/drivers/nsss.py
@@ -1,7 +1,7 @@
 # noinspection PyUnresolvedReferences
 import objc
 from AppKit import NSSpeechSynthesizer
-from Foundation import *
+from Foundation import NSURL, NSDate, NSDefaultRunLoopMode, NSObject, NSRunLoop, NSTimer
 from PyObjCTools import AppHelper
 
 # noinspection PyProtectedMember
@@ -150,10 +150,13 @@ class NSSpeechDriver(NSObject):
 
     @objc.python_method
     def save_to_file(self, text, filename):
+        """
+        Apple writes .aiff, not .wav. https://github.com/nateshmbhat/pyttsx3/issues/361
+        """
         self._proxy.setBusy(True)
         self._completed = True
         self._current_text = text
-        url = Foundation.NSURL.fileURLWithPath_(filename)
+        url = NSURL.fileURLWithPath_(filename)
         self._tts.startSpeakingString_toURL_(text, url)
 
     def speechSynthesizer_didFinishSpeaking_(self, tts, success):

--- a/tests/test_pyttsx3.py
+++ b/tests/test_pyttsx3.py
@@ -36,10 +36,10 @@ def test_speaking_text(engine):
     engine.runAndWait()
 
 
-@pytest.mark.xfail(
-    sys.platform == "darwin", reason="TODO: Fix this test to pass on macOS"
-)
 def test_saving_to_file(engine, tmp_path):
+    """
+    Apple writes .aiff, not .wav.  https://github.com/nateshmbhat/pyttsx3/issues/361
+    """
     test_file = tmp_path / "test.wav"  # Using .wav for easier validation
 
     # Save the speech to a file
@@ -53,10 +53,13 @@ def test_saving_to_file(engine, tmp_path):
     assert test_file.stat().st_size > 0, "The audio file is empty"
 
     # Check if the file is a valid .wav file using the wave module
-    with wave.open(str(test_file), "rb") as wf:
-        assert wf.getnchannels() == 1, "The audio file should have 1 channel (mono)"
-        assert wf.getsampwidth() == 2, "The audio file sample width should be 2 bytes"
-        assert wf.getframerate() == 22050, "The audio file framerate should be 22050 Hz"
+    try:
+        with wave.open(str(test_file), "rb") as wf:
+            assert wf.getnchannels() == 1, "The audio file should have 1 channel (mono)"
+            assert wf.getsampwidth() == 2, "Audio file sample width should be 2 bytes"
+            assert wf.getframerate() == 22050, "Audio file framerate should be 22050 Hz"
+    except wave.Error:
+        assert sys.platform in {"darwin", "ios"}, "Apple writes .aiff, not .wav files."
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fix our tests to deal with the `.aiff` vs. `.wav` issue discussed at https://github.com/nateshmbhat/pyttsx3/issues/361#issuecomment-2461907598

Also fixes a crash bug in `example/repeatvoice.py`.