### PR TITLE
README.md: Text-To-Speech Engines by Operating System

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.7.3
     hooks:  # Format before linting
       - id: ruff-format
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -93,13 +93,24 @@ engine.runAndWait()
 
 ### **Full documentation of the Library**
 
-https://pyttsx3.readthedocs.io/en/latest/
+https://pyttsx3.readthedocs.io
 
-#### Included TTS engines:
+#### Included Text-To-Speech Engines by Operating System
+|                         | Linux | macOS | Windows |
+|-------------------------|:-----:|:-----:|:-------:|
+| [AVSpeech][]            |       |   ✅︎  |         |
+| [eSpeak][]              |   ✅︎  |   ✅︎  |    ✅︎   |
+| [NSSpeechSynthesizer][] |       |   ✅︎  |         |
+| [SAPI5][]               |       |       |    ✅︎   |
 
-* espeak
-* nsss
-* sapi5
+> [!NOTE]
+> * AVSpeech support is still experimental.
+> * NSSpeechSynthesizer is deprecated by Apple.
+
+[AVSpeech]: https://developer.apple.com/documentation/avfoundation/speech_synthesis
+[eSpeak]: https://github.com/espeak-ng/espeak-ng?tab=readme-ov-file#readme
+[NSSpeechSynthesizer]: https://developer.apple.com/documentation/appkit/nsspeechsynthesizer
+[SAPI5]: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms723627(v=vs.85)
 
 Feel free to wrap another text-to-speech engine for use with ``pyttsx3``.
 


### PR DESCRIPTION
#### Included Text-To-Speech Engines by Operating System
|                         | Linux | macOS | Windows |
|-------------------------|:-----:|:-----:|:-------:|
| [AVSpeech][]            |       |   ✅︎  |         |
| [eSpeak][]              |   ✅︎  |   ✅︎  |    ✅︎   |
| [NSSpeechSynthesizer][] |       |   ✅︎  |         |
| [SAPI5][]               |       |       |    ✅︎   |

> [!NOTE]  
> * AVSpeech support is still experimental.
> * NSSpeechSynthesizer is deprecated by Apple.

[AVSpeech]: https://developer.apple.com/documentation/avfoundation/speech_synthesis
[eSpeak]: https://github.com/espeak-ng/espeak-ng?tab=readme-ov-file#readme
[NSSpeechSynthesizer]: https://developer.apple.com/documentation/appkit/nsspeechsynthesizer
[SAPI5]: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms723627(v=vs.85)

---

In future pull requests, we could add number of Voices, English Voices, % of test coverage, and notes about incompatibilities, etc.