### PR TITLE
SAPI - Language codes and other fields to not be Empty (fix for #384)

### DIFF
--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -110,13 +110,8 @@ class SAPI5Driver:
 
         # Retrieve gender
         gender_attr = attr.GetAttribute("Gender")
-        gender = (
-            "Male"
-            if gender_attr.lower() == "male"
-            else "Female"
-            if gender_attr.lower() == "female"
-            else None
-        )
+        gender_title_case = (gender or "").title()
+        gender = gender_title_case if gender_title_case in {"Male", "Female"} else None
 
         # Retrieve age
         age_attr = attr.GetAttribute("Age")

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -37,11 +37,11 @@ def buildDriver(proxy):
 
 def lcid_to_locale(language_code):
     primary, sub = language_code.split("-")
-    lcid = (int(sub) << 10) | int(primary)
+    locale_id = (int(sub) << 10) | int(primary)
     try:
-        return locale.windows_locale[lcid].replace("_", "-")
+        return locale.windows_locale[locale_id].replace("_", "-")
     except KeyError:
-        return "Unknown Locale"
+        return f"Unknown Locale: {locale_id}"
 
 
 # noinspection PyPep8Naming,PyShadowingNames

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -15,6 +15,7 @@ import math
 import os
 import time
 import weakref
+import locale
 
 import pythoncom
 
@@ -32,6 +33,15 @@ E_REG = {MSSAM: (137.89, 1.11), MSMARY: (156.63, 1.11), MSMIKE: (154.37, 1.11)}
 # noinspection PyPep8Naming
 def buildDriver(proxy):
     return SAPI5Driver(proxy)
+
+
+def lcid_to_locale(language_code):
+    primary, sub = language_code.split("-")
+    lcid = (int(sub) << 10) | int(primary)
+    try:
+        return locale.windows_locale[lcid].replace("_", "-")
+    except KeyError:
+        return "Unknown Locale"
 
 
 # noinspection PyPep8Naming,PyShadowingNames
@@ -88,7 +98,31 @@ class SAPI5Driver:
 
     @staticmethod
     def _toVoice(attr):
-        return Voice(attr.Id, attr.GetDescription())
+        # Retrieve voice ID and description (name)
+        voice_id = attr.Id
+        voice_name = attr.GetDescription()
+
+        # Retrieve and convert language code
+        language_attr = attr.GetAttribute("Language")
+        language_code = int(language_attr, 16)
+        primary_sub_code = f"{language_code & 0x3FF}-{(language_code >> 10) & 0x3FF}"
+        languages = [lcid_to_locale(primary_sub_code)]
+
+        # Retrieve gender
+        gender_attr = attr.GetAttribute("Gender")
+        gender = (
+            "male" if gender_attr == "1" else "female" if gender_attr == "2" else None
+        )
+
+        # Retrieve age
+        age_attr = attr.GetAttribute("Age")
+        age_map = {"1": "Child", "2": "Teen", "3": "Adult", "4": "Senior"}
+        age = age_map.get(age_attr, None)
+
+        # Create and return the Voice object with additional attributes
+        return Voice(
+            id=voice_id, name=voice_name, languages=languages, gender=gender, age=age
+        )
 
     def _tokenFromId(self, id_):
         tokens = self._tts.GetVoices()

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -111,12 +111,21 @@ class SAPI5Driver:
         # Retrieve gender
         gender_attr = attr.GetAttribute("Gender")
         gender = (
-            "male" if gender_attr == "1" else "female" if gender_attr == "2" else None
+            "Male"
+            if gender_attr.lower() == "male"
+            else "Female"
+            if gender_attr.lower() == "female"
+            else None
         )
 
         # Retrieve age
         age_attr = attr.GetAttribute("Age")
-        age_map = {"1": "Child", "2": "Teen", "3": "Adult", "4": "Senior"}
+        age_map = {
+            "Child": "Child",
+            "Teen": "Teen",
+            "Adult": "Adult",
+            "Senior": "Senior",
+        }
         age = age_map.get(age_attr, None)
 
         # Create and return the Voice object with additional attributes

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -110,7 +110,7 @@ class SAPI5Driver:
 
         # Retrieve gender
         gender_attr = attr.GetAttribute("Gender")
-        gender_title_case = (gender or "").title()
+        gender_title_case = (gender_attr or "").title()
         gender = gender_title_case if gender_title_case in {"Male", "Female"} else None
 
         # Retrieve age

--- a/pyttsx3/drivers/sapi5.py
+++ b/pyttsx3/drivers/sapi5.py
@@ -115,13 +115,7 @@ class SAPI5Driver:
 
         # Retrieve age
         age_attr = attr.GetAttribute("Age")
-        age_map = {
-            "Child": "Child",
-            "Teen": "Teen",
-            "Adult": "Adult",
-            "Senior": "Senior",
-        }
-        age = age_map.get(age_attr, None)
+        age = age_attr if age_attr in {"Child", "Teen", "Adult", "Senior"} else None
 
         # Create and return the Voice object with additional attributes
         return Voice(


### PR DESCRIPTION
nb; using locale to get correct lang codes that are understandable

This matches eSpeak too 

You should now get data like

```
<Voice id=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\TTS_MS_EN-US_DAVID_11.0
          name=Microsoft David Desktop - English (United States)
          languages=['en-US']
          gender=Male
          age=Adult>
<Voice id=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\TTS_MS_EN-US_ZIRA_11.0
          name=Microsoft Zira Desktop - English (United States)
          languages=['en-US']
          gender=Female
          age=Adult>
<Voice id=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\TTS_MS_ES-ES_HELENA_11.0
          name=Microsoft Helena Desktop - Spanish (Spain)
          languages=['es-ES']
          gender=Female
          age=Adult>
<Voice id=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\TTS_MS_FR-FR_HORTENSE_11.0
          name=Microsoft Hortense Desktop - French
          languages=['fr-FR']
          gender=Female
          age=Adult>
<Voice id=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\TTS_MS_RU-RU_IRINA_11.0
          name=Microsoft Irina Desktop - Russian
          languages=['ru-RU']
          gender=Female
          age=Adult>
```