### PR TITLE
fixed main.py and doc/readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,14 @@ voices = engine.getProperty('voices')       # getting details of current voice
 #engine.setProperty('voice', voices[0].id)  # changing index, changes voices. o for male
 engine.setProperty('voice', voices[1].id)   # changing index, changes voices. 1 for female
 
-engine.say("Hello World!")
+# speak at the new rate
 engine.say('My current speaking rate is ' + str(rate))
-engine.runAndWait()
-engine.stop()
 
 # Saving Voice to a file
 # On Linux, make sure that 'espeak-ng' is installed
 engine.save_to_file('Hello World', 'test.mp3')
 engine.runAndWait()
+engine.stop()
 ```
 
 ### **Full documentation of the Library**

--- a/docs/engine.rst
+++ b/docs/engine.rst
@@ -203,7 +203,6 @@ Speaking text
 
    import pyttsx3
    engine = pyttsx3.init()
-   engine.say('Sally sells seashells by the seashore.')
    engine.say('The quick brown fox jumped over the lazy dog.')
    engine.runAndWait()
 

--- a/example/main.py
+++ b/example/main.py
@@ -25,13 +25,11 @@ pitch = engine.getProperty("pitch")  # Get current pitch value
 print(pitch)  # Print current pitch value
 engine.setProperty("pitch", 75)  # Set the pitch (default 50) to 75 out of 100
 
-engine.say("Hello World!")
-engine.say("My current speaking rate is " + str(rate))
-engine.runAndWait()
-engine.stop()
-
+# speak at the new rate
+engine.say('My current speaking rate is ' + str(rate))
 
 # Saving Voice to a file
-# On linux make sure that 'espeak' is installed
+# On Linux, make sure that 'espeak' is installed
 engine.save_to_file("Hello World", "test.mp3")
 engine.runAndWait()
+engine.stop()


### PR DESCRIPTION
I ran into a bug where subsequent say() usage caused issues with pyttsx3 as a result of following examples in the documentation.

I updated the documentation to no longer use say() subsequently.