### PR TITLE
Add PEP 723 headers to the examples

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env -S uv run --script  # noqa: EXE003
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyttsx3",
+# ]
+# ///
+
 """pyttsx3 examples."""
 
 import pyttsx3

--- a/example/repeatvoice.py
+++ b/example/repeatvoice.py
@@ -1,3 +1,15 @@
+#!/usr/bin/env -S uv run --script  # noqa: EXE003
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "PyAudio",
+#     "pyttsx3",
+#     "SpeechRecognition",
+# ]
+# ///
+
+
 # pip3 install SpeechRecognition
 import speech_recognition  # A speech-to-text conversion library in Python
 


### PR DESCRIPTION
https://peps.python.org/pep-0723 enables Python files to have a header like:
```python
# /// script
# requires-python = ">=3.9"
# dependencies = [
#     "pyttsx3",
# ]
# ///
```
to Python scripts, which enables:
`pipx run examples/main.py` or
`uv run --script examples/main.py`.

When this command is run, `pipx` or `uv` will import the `dependencies` from PyPI, put them in an isolated `venv`, and then run the script in that `venv`.

https://thisdavej.com/share-python-scripts-like-a-pro-uv-and-pep-723-for-easy-deployment