### PR TITLE
On macOS v15.x, nsss has 177 voices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -49,7 +49,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.1
+    rev: v0.12.10
     hooks:  # Format before linting
       - id: ruff-check
       - id: ruff-format

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -115,9 +115,9 @@ def test_apple_nsss_voices(driver_name) -> None:
         )
     voices = engine.getProperty("voices")
     # On macOS v13.x or v14.x, nsss has 143 voices.
-    # On macOS v15.x, nsss has 176 voices
+    # On macOS v15.x, nsss has 177 voices
     print(f"On macOS v{macos_version}, {engine} has {len(voices) = } voices.")
-    assert len(voices) in {176, 143}, "Expected 176 or 143 voices on macOS and iOS"
+    assert len(voices) in {177, 143}, "Expected 177 or 143 voices on macOS and iOS"
     # print("\n".join(voice.id for voice in voices))
     en_us_voices = [voice for voice in voices if voice.id.startswith("com.apple.eloquence.en-US.")]
     assert len(en_us_voices) == 8, "Expected 8 com.apple.eloquence.en-US voices on macOS and iOS"

--- a/tests/test_pyttsx3.py
+++ b/tests/test_pyttsx3.py
@@ -59,9 +59,9 @@ def test_apple_avspeech_voices(engine):
     ), f"Expected default voice {voice} to be com.apple.voice.compact.en-US.Samantha"
     voices = engine.getProperty("voices")
     # On macOS v14.x, nsss has 143 voices.
-    # On macOS v15.x, nsss has 176 voices
+    # On macOS v15.x, nsss has 177 voices
     print(f"On macOS v{macos_version}, {engine} has {len(voices) = } voices.")
-    assert len(voices) in (176, 143), "Expected 176 or 143 voices on macOS and iOS"
+    assert len(voices) in {177, 143}, "Expected 177 or 143 voices on macOS and iOS"
     # print("\n".join(voice.id for voice in voices))
     en_us_voices = [voice for voice in voices if voice.id.startswith("com.apple.eloquence.en-US.")]
     assert len(en_us_voices) == 8, "Expected 8 com.apple.eloquence.en-US voices on macOS and iOS"
@@ -96,9 +96,9 @@ def test_apple_nsss_voices(engine):
     ), "Expected default voice to be com.apple.voice.compact.en-US.Samantha on macOS and iOS"
     voices = engine.getProperty("voices")
     # On macOS v14.x, nsss has 143 voices.
-    # On macOS v15.x, nsss has 176 voices
+    # On macOS v15.x, nsss has 177 voices
     print(f"On macOS v{macos_version}, {engine} has {len(voices) = } voices.")
-    assert len(voices) in (176, 143), "Expected 176 or 143 voices on macOS and iOS"
+    assert len(voices) in {177, 143}, "Expected 177 or 143 voices on macOS and iOS"
     # print("\n".join(voice.id for voice in voices))
     en_us_voices = [voice for voice in voices if voice.id.startswith("com.apple.eloquence.en-US.")]
     assert len(en_us_voices) == 8, "Expected 8 com.apple.eloquence.en-US voices on macOS and iOS"
@@ -201,7 +201,7 @@ def test_changing_volume(engine) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="TODO: Fix this test to pass on Windows")
 def test_changing_voices(engine) -> None:
     voices = engine.getProperty("voices")
-    for voice in voices:  # TODO: This could be lots of voices! (e.g. 176 on macOS v15.x)
+    for voice in voices:  # TODO: This could be lots of voices! (e.g. 177 on macOS v15.x)
         engine.setProperty("voice", voice.id)
         engine.say(f"{voice.id = }. {quick_brown_fox}")
     engine.runAndWait()


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v5.0.0 -> v6.0.0
[https://github.com/MarcoGorelli/auto-walrus] already up to date!
[https://github.com/codespell-project/codespell] already up to date!
[https://github.com/astral-sh/ruff-pre-commit] updating v0.12.1 -> v0.12.10
```
% `pre-commit run --all-files`