### PR TITLE
🔧 Fix: Code completion for `getProperty` & `setProperty`

### DIFF
--- a/pyttsx3/engine.py
+++ b/pyttsx3/engine.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Literal
 
 import sys
 import traceback
@@ -165,7 +166,7 @@ class Engine:
         """
         return self.proxy.isBusy()
 
-    def getProperty(self, name: str) -> object:
+    def getProperty(self, name: Literal['voices', 'voice', 'rate', 'volume']) -> object:
         """
         Gets the current value of a property. Valid names and values include:
 
@@ -186,7 +187,7 @@ class Engine:
         assert name
         return self.proxy.getProperty(name)
 
-    def setProperty(self, name: str, value: str | float) -> None:
+    def setProperty(self, name: Literal['voice', 'rate', 'volume'], value: str | float) -> None:
         """
         Adds a property value to set to the event queue. Valid names and values
         include:


### PR DESCRIPTION
# Let’s make IntelliSense awesome again!

Did you know that with just three lines of code, we’ve made `pyttsx3` way more convenient?

**Before:** We had to either ask `docs` or `AI` what we could do with `getProperty` & `setProperty`.
**Now:** With a simple `ctrl+space`, we can choose from a list of valid values. How cool is that?

## In pictures.
### Before:
<img width="838" height="413" alt="image" src="https://github.com/user-attachments/assets/114560e5-a02d-4ce7-b79f-658d51dccb12" />

### After:
<img width="784" height="364" alt="image" src="https://github.com/user-attachments/assets/05c68a35-09c8-43f6-be18-ab4ccb3ffba3" />

<img width="776" height="356" alt="image" src="https://github.com/user-attachments/assets/0a9b88d5-6039-4d25-acb1-bc9cd1e4b387" />


