### PR TITLE
docs: fix voice index comment (0 for male, not 'o')

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ engine.setProperty('volume',1.0)        # setting up volume level  between 0 and
 
 # VOICE
 voices = engine.getProperty('voices')       # getting details of current voice
-#engine.setProperty('voice', voices[0].id)  # changing index, changes voices. o for male
+#engine.setProperty('voice', voices[0].id)  # changing index, changes voices. 0 for male
 engine.setProperty('voice', voices[1].id)   # changing index, changes voices. 1 for female
 
 engine.say("Hello World!")


### PR DESCRIPTION
Corrects a small inconsistency in the README voice-selection example where the male voice index was written as the letter 'o' instead of 0, matching the '1 for female' comment on the following line.