### PR TITLE
Fix espeak Synth buffer size passed to espeak_Synth

### DIFF
--- a/pyttsx3/drivers/_espeak.py
+++ b/pyttsx3/drivers/_espeak.py
@@ -212,7 +212,7 @@ def Synth(  # noqa: PLR0913
         text = text.encode("utf-8")
     return cSynth(
         text,
-        len(text) * 10,
+        len(text) + 1,
         position,
         position_type,
         end_position,


### PR DESCRIPTION
## Summary
- Pass `len(text) + 1` to `espeak_Synth` instead of `len(text) * 10`.
- Matches `Synth_Mark` and the espeak API expectation for buffer size including the null terminator.

Fixes #448